### PR TITLE
Remove warning about archived flags in code

### DIFF
--- a/pages/feature-flags/organizing-flags/archiving-and-deleting.mdx
+++ b/pages/feature-flags/organizing-flags/archiving-and-deleting.mdx
@@ -16,10 +16,6 @@ Flags are good candidates for archival when they are **serving only one variatio
 
 When you archive a flag in FeatBit, you should also remove the flag from your code.
 
-<Callout type="warning">
-If you do not remove an archived flag from your code, then all end users encountering the feature will receive the fallback value.
-</Callout>
-
 <Callout type="error">
 Be absolutely certain you can archive a flag without any unintended impact.
 </Callout>


### PR DESCRIPTION
Removed warning callout about not removing archived flags from code. 

This warning is incorrect based on our testing.

Currently, if a flag is archived, the SDKs will still serve the value that was set when the flag was archived. Archiving does not appear to affect the state that a flag serves.